### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,10 @@ You can clone the repository by following these steps:
 	- `git clone https://github.com/EfthymiaKakoulidou/cakes-by-kg.git`
 7. Press Enter to create your local clone.
 
-Alternatively, if using Gitpod, you can click below to create your own workspace using this repository.
+Alternatively, if using Gitpod or Codeanyhwere, you can click below to create your own workspace using this repository.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/EfthymiaKakoulidou/cakes-by-kg)
+[![Open in  Codeanyhwere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/EfthymiaKakoulidou/cakes-by-kg)
 
 Please note that in order to directly open the project in Gitpod, you need to have the browser extension installed.
 A tutorial on how to do that can be found [here](https://www.gitpod.io/docs/configure/user-settings/browser-extension).


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.